### PR TITLE
Added style config and stylized.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 iiag
+*.orig

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ LDFL := -Wall -Werror -lm
 # List of source files
 SRCS := $(subst src/,,$(shell find src -name \*.c -type f))
 
+# List of all the source and headers, rooted at .
+ALL_SRCS := $(shell find src \( -name \*.c -o -name \*.h \) -type f)
+
+# List of all the "orig" files
+ALL_ORIG := $(shell find src -name *.orig -type f)
+
 # Construct file lists
 OBJS := $(addprefix build/obj/,$(patsubst %.c,%.o,$(SRCS)))
 DEPS := $(addprefix build/dep/,$(patsubst %.c,%.d,$(SRCS)))
@@ -30,7 +36,7 @@ TEST_OBJS = $(filter-out build/obj/main.o,$(OBJS))
 TESTER = valgrind -q
 
 # All the make rules
-.PHONY: all clean install test FORCE_RULE
+.PHONY: all clean install test style style_clean FORCE_RULE
 
 all: $(TARGET)
 
@@ -54,13 +60,19 @@ test: all $(TESTS)
 	@ echo " > running..."
 	@ $(TESTER) build/$(@D)
 
-clean:
+clean: style_clean
 	rm -rf build
 	rm -f $(TARGET)
 
 install: all
 	mkdir -p $(DESTDIR)
 	cp $(TARGET) $(DESTDIR)
+
+style: $(ALL_SRCS)
+	astyle -tSjp -A2 -k3 -W3 $^
+
+style_clean: $(ALL_ORIG)
+	rm -f $^
 
 # Include automagically generated dependencies
 -include $(DEPS)

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,4 @@
 
-int main(int argc, char ** argv)
-{
+int main(int argc, char **argv) {
 	return 0;
 }

--- a/src/util/list.c
+++ b/src/util/list.c
@@ -1,20 +1,32 @@
+#include <stdio.h>
 #include <stdlib.h>
 #include "list.h"
+
+typedef struct list_elm list_elm_t;
+
+struct list {
+	list_elm_t *front;
+	list_elm_t *back;
+	size_t size;
+};
 
 struct list_elm {
 	void *value;
 	list_elm_t *next;
+	list_elm_t *prev;
 };
 
 list_t *list_new(void) {
 	list_t *ls = malloc(sizeof(list_t));
-	*ls = NULL;
+	ls->front = NULL;
+	ls->back = NULL;
+	ls->size = 0;
 	return ls;
 }
 
 void list_destroy(list_t *ls) {
 	list_elm_t *tmp;
-	list_elm_t *elm = *ls;
+	list_elm_t *elm = ls->front;
 
 	while (elm) {
 		tmp = elm->next;
@@ -27,28 +39,113 @@ void list_destroy(list_t *ls) {
 
 void list_push(list_t *ls, void *value) {
 	list_elm_t *elm = malloc(sizeof(list_elm_t));
+
 	elm->value = value;
-	elm->next = *ls;
-	*ls = elm;
+	elm->next = ls->front;
+	elm->prev = NULL;
+
+	if (ls->back) {
+		// Is not the first element in the list
+		ls->front->prev = elm;
+	} else {
+		// Is the first element in the list
+		ls->back = elm;
+	}
+
+	ls->size++;
+	ls->front = elm;
 }
 
 void *list_pop(list_t *ls) {
 	void *value;
 	list_elm_t *elm;
 
-	elm = *ls;
-	value = elm->value;
-	*ls = elm->next;
-	free(elm);
+	if (ls->front) {
+		elm = ls->front;
+		value = elm->value;
+
+		if (ls->front == ls->back) {
+			// Last element in list
+			ls->back = NULL;
+		} else {
+			// Not last element in list
+			ls->front->next->prev = NULL;
+		}
+
+		ls->size--;
+		ls->front = elm->next;
+		free(elm);
+	} else {
+		// Nothing to pop, return null
+		value = NULL;
+	}
 
 	return value;
 }
 
+void list_push_back(list_t *ls, void *value) {
+	list_elm_t *elm = malloc(sizeof(list_elm_t));
+
+	elm->value = value;
+	elm->next = NULL;
+	elm->prev = ls->back;
+
+	if (ls->front) {
+		// other elements in list
+		ls->back->next = elm;
+	} else {
+		// first element in list
+		ls->front = elm;
+	}
+
+	ls->size++;
+	ls->back = elm;
+}
+
+void *list_pop_back(list_t *ls) {
+	void *value;
+	list_elm_t *elm;
+
+	if (ls->back) {
+		elm = ls->back;
+		value = elm->value;
+
+		if (ls->front == ls->back) {
+			// Last element in list
+			ls->front = NULL;
+		} else {
+			ls->back->prev->next = NULL;
+		}
+
+		ls->size--;
+		ls->back = elm->prev;
+		free(elm);
+	} else {
+		// Nothing left to pop, return null
+		value = NULL;
+	}
+
+	return value;
+}
+
+int list_size(list_t *ls) {
+	return ls->size;
+}
+
 void list_foreach(list_t *ls, void *arg2, list_foreach_func func) {
-	list_elm_t *elm = *ls;
+	list_elm_t *elm = ls->front;
 
 	while (elm) {
 		func(elm->value, arg2);
 		elm = elm->next;
+	}
+}
+
+void list_foreach_reverse(list_t *ls, void *arg2, list_foreach_func func) {
+	list_elm_t *elm = ls->back;
+
+	while (elm) {
+		func(elm->value, arg2);
+		elm = elm->prev;
 	}
 }

--- a/src/util/list.c
+++ b/src/util/list.c
@@ -2,21 +2,19 @@
 #include "list.h"
 
 struct list_elm {
-	void * value;
-	list_elm_t * next;
+	void *value;
+	list_elm_t *next;
 };
 
-list_t * list_new(void)
-{
-	list_t * ls = malloc(sizeof(list_t));
+list_t *list_new(void) {
+	list_t *ls = malloc(sizeof(list_t));
 	*ls = NULL;
 	return ls;
 }
 
-void list_destroy(list_t * ls)
-{
-	list_elm_t * tmp;
-	list_elm_t * elm = *ls;
+void list_destroy(list_t *ls) {
+	list_elm_t *tmp;
+	list_elm_t *elm = *ls;
 
 	while (elm) {
 		tmp = elm->next;
@@ -27,18 +25,16 @@ void list_destroy(list_t * ls)
 	free(ls);
 }
 
-void list_push(list_t * ls, void * value)
-{
-	list_elm_t * elm = malloc(sizeof(list_elm_t));
+void list_push(list_t *ls, void *value) {
+	list_elm_t *elm = malloc(sizeof(list_elm_t));
 	elm->value = value;
 	elm->next = *ls;
 	*ls = elm;
 }
 
-void * list_pop(list_t * ls)
-{
-	void * value;
-	list_elm_t * elm;
+void *list_pop(list_t *ls) {
+	void *value;
+	list_elm_t *elm;
 
 	elm = *ls;
 	value = elm->value;
@@ -48,9 +44,8 @@ void * list_pop(list_t * ls)
 	return value;
 }
 
-void list_foreach(list_t * ls, void * arg2, list_foreach_func func)
-{
-	list_elm_t * elm = *ls;
+void list_foreach(list_t *ls, void *arg2, list_foreach_func func) {
+	list_elm_t *elm = *ls;
 
 	while (elm) {
 		func(elm->value, arg2);

--- a/src/util/list.c
+++ b/src/util/list.c
@@ -1,34 +1,20 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include "list.h"
 
-typedef struct list_elm list_elm_t;
-
-struct list {
-	list_elm_t * front;
-	list_elm_t * back;
-	size_t size;
-};
-
 struct list_elm {
-	void * value;
-	list_elm_t * next;
-	list_elm_t * prev;
+	void *value;
+	list_elm_t *next;
 };
 
-list_t * list_new(void)
-{
-	list_t * ls = malloc(sizeof(list_t));
-	ls->front = NULL;
-	ls->back = NULL;
-	ls->size = 0;
+list_t *list_new(void) {
+	list_t *ls = malloc(sizeof(list_t));
+	*ls = NULL;
 	return ls;
 }
 
-void list_destroy(list_t * ls)
-{
-	list_elm_t * tmp;
-	list_elm_t * elm = ls->front;
+void list_destroy(list_t *ls) {
+	list_elm_t *tmp;
+	list_elm_t *elm = *ls;
 
 	while (elm) {
 		tmp = elm->next;
@@ -39,122 +25,30 @@ void list_destroy(list_t * ls)
 	free(ls);
 }
 
-void list_push(list_t * ls, void * value)
-{
-	list_elm_t * elm = malloc(sizeof(list_elm_t));
-
+void list_push(list_t *ls, void *value) {
+	list_elm_t *elm = malloc(sizeof(list_elm_t));
 	elm->value = value;
-	elm->next = ls->front;
-	elm->prev = NULL;
-
-	if (ls->back) {
-		// Is not the first element in the list
-		ls->front->prev = elm;
-	} else {
-		// Is the first element in the list
-		ls->back = elm;
-	}
-
-	ls->size++;
-	ls->front = elm;
+	elm->next = *ls;
+	*ls = elm;
 }
 
-void * list_pop(list_t * ls)
-{
-	void * value;
-	list_elm_t * elm;
+void *list_pop(list_t *ls) {
+	void *value;
+	list_elm_t *elm;
 
-	if (ls->front) {
-		elm = ls->front;
-		value = elm->value;
-
-		if (ls->front == ls->back) {
-			// Last element in list
-			ls->back = NULL;
-		} else {
-			// Not last element in list
-			ls->front->next->prev = NULL;
-		}
-
-		ls->size--;
-		ls->front = elm->next;
-		free(elm);
-	} else {
-		// Nothing to pop, return null
-		value = NULL;
-	}
+	elm = *ls;
+	value = elm->value;
+	*ls = elm->next;
+	free(elm);
 
 	return value;
 }
 
-void list_push_back(list_t * ls, void * value)
-{
-	list_elm_t * elm = malloc(sizeof(list_elm_t));
-
-	elm->value = value;
-	elm->next = NULL;
-	elm->prev = ls->back;
-
-	if (ls->front) {
-		// other elements in list
-		ls->back->next = elm;
-	} else {
-		// first element in list
-		ls->front = elm;
-	}
-
-	ls->size++;
-	ls->back = elm;
-}
-
-void * list_pop_back(list_t * ls)
-{
-	void * value;
-	list_elm_t * elm;
-
-	if (ls->back) {
-		elm = ls->back;
-		value = elm->value;
-
-		if (ls->front == ls->back) {
-			// Last element in list
-			ls->front = NULL;
-		} else {
-			ls->back->prev->next = NULL;
-		}
-
-		ls->size--;
-		ls->back = elm->prev;
-		free(elm);
-	} else {
-		// Nothing left to pop, return null
-		value = NULL;
-	}
-
-	return value;
-}
-
-int list_size(list_t * ls)
-{
-	return ls->size;
-}
-
-void list_foreach(list_t * ls, void * arg2, list_foreach_func func)
-{
-	list_elm_t * elm = ls->front;
+void list_foreach(list_t *ls, void *arg2, list_foreach_func func) {
+	list_elm_t *elm = *ls;
 
 	while (elm) {
 		func(elm->value, arg2);
 		elm = elm->next;
-	}
-}
-
-void list_foreach_reverse(list_t * ls, void * arg2, list_foreach_func func)
-{
-	list_elm_t * elm = ls->back;
-
-	while (elm) {
-		func(elm->value, arg2);
-		elm = elm->prev;
 	}
 }

--- a/src/util/list.h
+++ b/src/util/list.h
@@ -1,8 +1,7 @@
 #ifndef LIST_H
 #define LIST_H
 
-typedef struct list_elm list_elm_t;
-typedef list_elm_t *list_t;
+typedef struct list list_t;
 
 typedef void (* list_foreach_func)(void *, void *);
 
@@ -19,8 +18,20 @@ void list_push(list_t *, void *);
 // Pops an element from the begining of the list
 void *list_pop(list_t *);
 
+// Pushes an element to the end of the list
+void list_push_back(list_t *, void *);
+
+// Pops an element from the end of the list
+void *list_pop_back(list_t *);
+
+// Gets the number of elements in the list
+int list_size(list_t *);
+
 // Applies a function to each element in the list
 // The first argument to the given function will be the element's value, the 2nd `arg2`
 void list_foreach(list_t *, void *arg2, list_foreach_func);
+
+// Same as list_foreach but from back to front
+void list_foreach_reverse(list_t *, void *arg2, list_foreach_func);
 
 #endif

--- a/src/util/list.h
+++ b/src/util/list.h
@@ -2,12 +2,12 @@
 #define LIST_H
 
 typedef struct list_elm list_elm_t;
-typedef list_elm_t * list_t;
+typedef list_elm_t *list_t;
 
 typedef void (* list_foreach_func)(void *, void *);
 
 // Instantiates a new, empty list
-list_t * list_new(void);
+list_t *list_new(void);
 
 // Frees a list and all elements in it
 // Call list_foreach if custom destruct logic is needed
@@ -17,10 +17,10 @@ void list_destroy(list_t *);
 void list_push(list_t *, void *);
 
 // Pops an element from the begining of the list
-void * list_pop(list_t *);
+void *list_pop(list_t *);
 
 // Applies a function to each element in the list
 // The first argument to the given function will be the element's value, the 2nd `arg2`
-void list_foreach(list_t *, void * arg2, list_foreach_func);
+void list_foreach(list_t *, void *arg2, list_foreach_func);
 
 #endif

--- a/src/util/list.h
+++ b/src/util/list.h
@@ -1,12 +1,13 @@
 #ifndef LIST_H
 #define LIST_H
 
-typedef struct list list_t;
+typedef struct list_elm list_elm_t;
+typedef list_elm_t *list_t;
 
 typedef void (* list_foreach_func)(void *, void *);
 
 // Instantiates a new, empty list
-list_t * list_new(void);
+list_t *list_new(void);
 
 // Frees a list and all elements in it
 // Call list_foreach if custom destruct logic is needed
@@ -16,22 +17,10 @@ void list_destroy(list_t *);
 void list_push(list_t *, void *);
 
 // Pops an element from the begining of the list
-void * list_pop(list_t *);
-
-// Pushes an element to the end of the list
-void list_push_back(list_t *, void *);
-
-// Pops an element from the end of the list
-void * list_pop_back(list_t *);
-
-// Gets the number of elements in the list
-int list_size(list_t *);
+void *list_pop(list_t *);
 
 // Applies a function to each element in the list
 // The first argument to the given function will be the element's value, the 2nd `arg2`
-void list_foreach(list_t *, void * arg2, list_foreach_func);
-
-// Same as list_foreach but from back to front
-void list_foreach_reverse(list_t *, void * arg2, list_foreach_func);
+void list_foreach(list_t *, void *arg2, list_foreach_func);
 
 #endif


### PR DESCRIPTION
Config options are (for those who can't be bothered to sift the man pages):
-t: Use one tab for indents [and treat one tab as four spaces, though this is mostly unimportant]
-S: Indent cases in switches (personal preference)
-j: Brace and indent one-statement controls (like 1tbs, personal preference)
-p: Pad operators (personal preference)
-A2: Java style, attach every brace (see -j)
-k3: Attach \* to variable name
-W3: Attach & to variable name (just in case :)
Sift for your approval, the code this would generate is in this commit.

This code passes my kosher test for all but a few nuances (no automatic space-conv because of a nonstandard tab size, accidentally seems to pad the \* in function pointers); like it or not, I should probably push this to my C projects :P 

Criticism welcome; also, the [man pages here](http://astyle.sourceforge.net/astyle.html) are undoubtedly useful.
